### PR TITLE
Bump version of docker to match what is used by new Carina clusters

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -135,7 +135,7 @@
               <li>Utility for managing Docker client versions</li>
               <li><a href="https://getcarina.com/docs/tutorials/docker-version-manager/" target="_blank">Manage Docker client versions with dvm</a></li>
               <li>Do the <b>Install dvm</b> section only</li>
-              <li><code>dvm install 1.10.1</code></li>
+              <li><code>dvm install 1.11.1</code></li>
             </ol>
             <li>Carina CLI</li>
             <ol>
@@ -264,10 +264,10 @@ communicate with your Swarm Cluster...</span>
 <span class="fragment">DOCKER_HOST=tcp://146.20.68.14:2376
 DOCKER_TLS_VERIFY=1
 DOCKER_CERT_PATH=/Users/everett/Downloads/mycluster
-DOCKER_VERSION=1.10.1</span>
+DOCKER_VERSION=1.11.1</span>
 
 <span class="fragment">$ dvm use</span>
-<span class="fragment">Now using Docker 1.10.1</span>
+<span class="fragment">Now using Docker 1.11.1</span>
           </code></pre>
           <aside class="notes">
             Whiteboard the architecture so far.


### PR DESCRIPTION
Update the slides to show the same version that participants will see after making a new cluster.
